### PR TITLE
DO-4048 Fix nginx 502 error by removing manual URI construction

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -39,7 +39,7 @@ http {
 
       # Only requests matching the whitelist expectations will
       # get sent to the application server
-      proxy_pass $APP_SERVER$uri$is_args$args;
+      proxy_pass $APP_SERVER;
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
Remove $uri$is_args$args from proxy_pass directive to fix 502 Bad Gateway errors. When proxy_pass contains variables in the URI portion, nginx requires a resolver directive even for static hostnames like localhost. By using just $APP_SERVER, nginx automatically handles URI forwarding without needing runtime DNS resolution.

This allows the merge_slashes directive to work correctly at the http level while maintaining proper request proxying to the upstream application server.