### PR TITLE
DO-4048 Use trailing slash in proxy_pass to handle double-slash URIs

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -9,7 +9,7 @@ http {
   gzip_types application/json;
   gzip_min_length 1000;
   merge_slashes on;
-  
+
   map "$request_uri,$http_user_agent" $log_ua {
     "~/health.*check,ELB-HealthChecker/2.0" 1;
     "~/health.*check,ELB-HealthChecker/1.0" 1;
@@ -39,7 +39,8 @@ http {
 
       # Only requests matching the whitelist expectations will
       # get sent to the application server
-      proxy_pass $APP_SERVER;
+      # Trailing slash ensures nginx uses the rewritten/normalized URI
+      proxy_pass $APP_SERVER/;
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
Change proxy_pass from $APP_SERVER to $APP_SERVER/ to ensure nginx uses the rewritten/normalized URI when forwarding to the upstream application.

When proxy_pass includes a URI (even just /), nginx removes the matched location prefix from the request URI and appends the remainder to the proxy_pass URI. This ensures double-slash paths like //v1/people are properly normalized to /v1/people before proxying.

This approach:
- Does not require a resolver directive (no variables in proxy_pass)
- Works correctly with merge_slashes and rewrite rules
- Follows standard nginx best practices for URI normalization

Fixes the issue where NGF sends $request_uri (with double slashes) to the sidecar, which must normalize before forwarding to the app.